### PR TITLE
chore(scripts): Make storybook the "default" development script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { Text, theme } from '@marigold/components'
 Start your local storybook server via
 
 ```
-yarn storybook
+yarn start
 ```
 
 to access the Marigold documentation pages.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "contributors:generate": "all-contributors generate",
     "coverage": "jest --config jest.config.js --coverage --coverageReporters html",
     "lint": "eslint . --format=pretty --ext .ts,.tsx",
-    "storybook": "start-storybook",
+    "start": "start-storybook",
     "test": "jest --config jest.config.js",
     "typecheck": "tsc --noEmit"
   }


### PR DESCRIPTION
BREAKING CHANGE: Storybook files must  be of the format `*.stories.mdx`.